### PR TITLE
#273728 #273729 #273730 #273731 #273733 #273734 Support historical co…

### DIFF
--- a/JsonToWord.Tests/Controllers.Tests/WordControllerTests.cs
+++ b/JsonToWord.Tests/Controllers.Tests/WordControllerTests.cs
@@ -1,12 +1,16 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using DocumentFormat.OpenXml;
 using DocumentFormat.OpenXml.Packaging;
 using DocumentFormat.OpenXml.Wordprocessing;
+using JsonToWord;
 using JsonToWord.Controllers;
 using JsonToWord.Models;
 using JsonToWord.Models.S3;
+using JsonToWord.Services;
 using JsonToWord.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -59,8 +63,15 @@ namespace JsonToWord.Controllers.Tests
                 };
 
                 var wordService = new Mock<IWordService>();
+                var callOrder = new List<string>();
                 wordService.Setup(s => s.Create(It.IsAny<WordModel>())).Returns(templatePath);
-                wordService.Setup(s => s.CreateDownloadableFile(templatePath)).Returns(downloadable);
+                wordService
+                    .Setup(s => s.CreateDownloadableFile(templatePath))
+                    .Callback(() => callOrder.Add("download"))
+                    .Returns(downloadable);
+                awsService
+                    .Setup(s => s.CleanUp(templatePath))
+                    .Callback(() => callOrder.Add("cleanup"));
 
                 var controller = new WordController(
                     awsService.Object,
@@ -81,11 +92,190 @@ namespace JsonToWord.Controllers.Tests
                 Assert.Same(downloadable, ok.Value);
                 wordService.Verify(s => s.Create(It.IsAny<WordModel>()), Times.Once);
                 awsService.Verify(s => s.CleanUp(templatePath), Times.Once);
+                Assert.Equal(new[] { "download", "cleanup" }, callOrder);
             }
             finally
             {
                 Directory.Delete(tempDir, true);
             }
+        }
+
+        [Fact]
+        public async Task CreateWordDocument_WithoutTemplatePath_BuildsTemporaryTemplateFromContentControls()
+        {
+            var awsService = new Mock<IAWSS3Service>();
+            WordModel capturedModel = null;
+
+            var downloadable = new DownloadableObjectModel
+            {
+                FileName = "historical-report.docx",
+                Base64 = Convert.ToBase64String(new byte[] { 1, 2, 3 }),
+                ApplicationType = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            };
+
+            var wordService = new Mock<IWordService>();
+            wordService
+                .Setup(s => s.Create(It.IsAny<WordModel>()))
+                .Callback<WordModel>(model =>
+                {
+                    capturedModel = model;
+                    Assert.False(string.IsNullOrWhiteSpace(model?.LocalPath));
+                    Assert.True(File.Exists(model.LocalPath));
+                })
+                .Returns<WordModel>(model => model.LocalPath);
+            wordService
+                .Setup(s => s.CreateDownloadableFile(It.IsAny<string>()))
+                .Returns(downloadable);
+
+            var controller = new WordController(
+                awsService.Object,
+                wordService.Object,
+                new Mock<ILogger<WordController>>().Object);
+
+            var payload = JObject.FromObject(new
+            {
+                UploadProperties = new { FileName = "historical-report.docx", EnableDirectDownload = true },
+                ContentControls = new[]
+                {
+                    new { Title = "historical-compare-report-content-control", WordObjects = new object[0] }
+                },
+                FormattingSettings = new { ProcessVoidList = false }
+            });
+
+            var result = await controller.CreateWordDocument(payload);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Same(downloadable, ok.Value);
+            Assert.NotNull(capturedModel);
+            Assert.Equal("historical-report.docx", Path.GetFileName(capturedModel.LocalPath));
+            awsService.Verify(s => s.DownloadFileFromS3BucketAsync(It.IsAny<Uri>(), It.IsAny<string>()), Times.Never);
+            wordService.Verify(s => s.CreateDownloadableFile(capturedModel.LocalPath), Times.Once);
+            awsService.Verify(s => s.CleanUp(capturedModel.LocalPath), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateWordDocument_WithoutTemplatePath_UsesRequestedFileNameForUpload()
+        {
+            var awsService = new Mock<IAWSS3Service>();
+            WordModel capturedModel = null;
+            UploadProperties capturedUploadProperties = null;
+
+            var wordService = new Mock<IWordService>();
+            wordService
+                .Setup(s => s.Create(It.IsAny<WordModel>()))
+                .Callback<WordModel>(model =>
+                {
+                    capturedModel = model;
+                    Assert.False(string.IsNullOrWhiteSpace(model?.LocalPath));
+                    Assert.True(File.Exists(model.LocalPath));
+                })
+                .Returns<WordModel>(model => model.LocalPath);
+
+            awsService
+                .Setup(s => s.UploadFileToMinioBucketAsync(It.IsAny<UploadProperties>()))
+                .Callback<UploadProperties>(props => capturedUploadProperties = props)
+                .ReturnsAsync(new AWSUploadResult<string> { Status = true, Data = "https://minio.example/historical-report.docx" });
+
+            var controller = new WordController(
+                awsService.Object,
+                wordService.Object,
+                new Mock<ILogger<WordController>>().Object);
+
+            var payload = JObject.FromObject(new
+            {
+                UploadProperties = new
+                {
+                    FileName = "historical-report.docx",
+                    EnableDirectDownload = false,
+                    BucketName = "bucket"
+                },
+                ContentControls = new[]
+                {
+                    new { Title = "historical-compare-report-content-control", WordObjects = new object[0] }
+                },
+                FormattingSettings = new { ProcessVoidList = false }
+            });
+
+            var result = await controller.CreateWordDocument(payload);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            Assert.Equal("https://minio.example/historical-report.docx", ok.Value);
+            Assert.NotNull(capturedModel);
+            Assert.NotNull(capturedUploadProperties);
+            Assert.Equal("historical-report.docx", Path.GetFileName(capturedModel.LocalPath));
+            Assert.Equal("historical-report.docx", Path.GetFileName(capturedUploadProperties.LocalFilePath));
+            awsService.Verify(s => s.CleanUp(capturedModel.LocalPath), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateWordDocument_TimeMachineHtmlPayload_RendersHtmlToWordDocument()
+        {
+            var awsService = new Mock<IAWSS3Service>();
+            var controller = new WordController(
+                awsService.Object,
+                CreateRealWordService(),
+                new Mock<ILogger<WordController>>().Object);
+
+            const string reportHtml = @"
+                <html>
+                    <body>
+                        <h1>Time machine summary</h1>
+                        <p>Snapshot comparison generated from historical query data.</p>
+                        <table>
+                            <tr><th>Work Item</th><th>Status</th></tr>
+                            <tr><td>Work Item 101</td><td>Added</td></tr>
+                            <tr><td>Work Item 202</td><td>Removed</td></tr>
+                        </table>
+                    </body>
+                </html>";
+
+            var payload = JObject.FromObject(new
+            {
+                UploadProperties = new
+                {
+                    FileName = "time-machine-report.docx",
+                    EnableDirectDownload = true
+                },
+                ContentControls = new[]
+                {
+                    new
+                    {
+                        Title = "historical-compare-report-content-control",
+                        WordObjects = new[]
+                        {
+                            new
+                            {
+                                type = "Html",
+                                html = reportHtml,
+                                font = "Calibri",
+                                fontSize = 11
+                            }
+                        }
+                    }
+                },
+                FormattingSettings = new
+                {
+                    ProcessVoidList = false
+                }
+            });
+
+            var result = await controller.CreateWordDocument(payload);
+
+            var ok = Assert.IsType<OkObjectResult>(result);
+            var downloadable = Assert.IsType<DownloadableObjectModel>(ok.Value);
+            Assert.Equal("time-machine-report.docx", downloadable.FileName);
+            Assert.Equal("application/vnd.openxmlformats-officedocument.wordprocessingml.document", downloadable.ApplicationType);
+
+            var generatedDocumentBytes = Convert.FromBase64String(downloadable.Base64);
+            using var stream = new MemoryStream(generatedDocumentBytes);
+            using var generatedDocument = WordprocessingDocument.Open(stream, false);
+            var renderedText = string.Join(" ", generatedDocument.MainDocumentPart.Document.Body.Descendants<Text>().Select(t => t.Text));
+
+            Assert.Contains("Work Item 101", renderedText);
+            Assert.Contains("Added", renderedText);
+            Assert.Contains("Removed", renderedText);
+            Assert.Contains("Snapshot comparison generated from historical query data.", renderedText);
+            awsService.Verify(s => s.DownloadFileFromS3BucketAsync(It.IsAny<Uri>(), It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
@@ -276,6 +466,33 @@ namespace JsonToWord.Controllers.Tests
             var result = controller.CreateWordDocumentByFile(payload);
 
             Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        private static IWordService CreateRealWordService()
+        {
+            var contentControlService = new ContentControlService(
+                new Mock<ILogger<ContentControlService>>().Object,
+                new DocumentValidatorService(new Mock<ILogger<DocumentValidatorService>>().Object));
+
+            var pictureService = new Mock<IPictureService>();
+            var htmlService = new HtmlService(
+                contentControlService,
+                new DocumentValidatorService(new Mock<ILogger<DocumentValidatorService>>().Object),
+                new Mock<ILogger<HtmlService>>().Object,
+                pictureService.Object,
+                new ParagraphService());
+
+            return new WordService(
+                contentControlService,
+                Mock.Of<ITableService>(),
+                pictureService.Object,
+                Mock.Of<ITextService>(),
+                htmlService,
+                Mock.Of<IFileService>(),
+                Mock.Of<IVoidListService>(),
+                new DocumentService(new Mock<ILogger<DocumentService>>().Object),
+                new SectionPlaceholderService(new Mock<ILogger<SectionPlaceholderService>>().Object),
+                new Mock<ILogger<WordService>>().Object);
         }
     }
 }

--- a/src/Controllers/WordController.cs
+++ b/src/Controllers/WordController.cs
@@ -2,6 +2,9 @@
 using JsonToWord.Models;
 using JsonToWord.Models.S3;
 using JsonToWord.Services.Interfaces;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -10,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 
@@ -41,10 +45,11 @@ namespace JsonToWord.Controllers
         [HttpPost("create")]
         public async Task<IActionResult> CreateWordDocument(dynamic json)
         {
+            var attachmentPaths = new List<String>();
+            var cleanupPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             try
             {
                 var settings = new JsonSerializerSettings();
-                var attachmentPaths = new List<String>();
                 settings.Converters.Add(new WordObjectConverter());
                 WordModel wordModel = JsonConvert.DeserializeObject<WordModel>(json.ToString(), settings);
                 if (wordModel.JsonDataList != null)
@@ -86,7 +91,8 @@ namespace JsonToWord.Controllers
                         _aWSS3Service.CleanUp(contentControlPath);
                     }
                 }
-                string fullpath = _aWSS3Service.DownloadFileFromS3BucketAsync(wordModel.TemplatePath, wordModel.UploadProperties.FileName);
+                string fullpath = ResolveTemplatePath(wordModel);
+                AddCleanupPath(cleanupPaths, fullpath);
                 wordModel.LocalPath = fullpath;
                 _logger.LogInformation("Initilized word model object");
                 if (wordModel.MinioAttachmentData != null)
@@ -97,9 +103,8 @@ namespace JsonToWord.Controllers
                     }
                 }
                 var documentPath = _wordService.Create(wordModel);
+                AddCleanupPath(cleanupPaths, documentPath);
                 _logger.LogInformation("Created word document");
-
-                _aWSS3Service.CleanUp(fullpath);
 
                 wordModel.UploadProperties.LocalFilePath = documentPath;
 
@@ -111,12 +116,6 @@ namespace JsonToWord.Controllers
                 else
                 {
                     AWSUploadResult<string> Response = await _aWSS3Service.UploadFileToMinioBucketAsync(wordModel.UploadProperties);
-                    _aWSS3Service.CleanUp(documentPath);
-
-                    foreach (var item in attachmentPaths)
-                    {
-                        _aWSS3Service.CleanUp(item);
-                    }
                     if (Response.Status)
                     {
                         return Ok(Response.Data);
@@ -141,6 +140,170 @@ namespace JsonToWord.Controllers
                 };
 
                 return BadRequest(JsonConvert.SerializeObject(errorResponse));
+            }
+            finally
+            {
+                foreach (var item in attachmentPaths)
+                {
+                    SafeCleanUp(item);
+                }
+
+                foreach (var path in cleanupPaths)
+                {
+                    SafeCleanUp(path);
+                }
+            }
+        }
+
+        private string ResolveTemplatePath(WordModel wordModel)
+        {
+            if (HasUsableTemplatePath(wordModel?.TemplatePath))
+            {
+                return _aWSS3Service.DownloadFileFromS3BucketAsync(
+                    wordModel.TemplatePath,
+                    wordModel?.UploadProperties?.FileName ?? "template.docx"
+                );
+            }
+
+            _logger.LogInformation("TemplatePath is missing or not absolute. Building a temporary template from content controls.");
+            return BuildTemporaryTemplate(wordModel);
+        }
+
+        private static bool HasUsableTemplatePath(Uri templatePath)
+        {
+            if (templatePath == null) return false;
+            var rawValue = templatePath.ToString();
+            if (string.IsNullOrWhiteSpace(rawValue)) return false;
+            if (string.Equals(rawValue.Trim(), "template path", StringComparison.OrdinalIgnoreCase)) return false;
+            return templatePath.IsAbsoluteUri;
+        }
+
+        private static string NormalizeFileToken(string value)
+        {
+            var safe = string.IsNullOrWhiteSpace(value) ? "generated-report" : value.Trim();
+            var invalidChars = Path.GetInvalidFileNameChars();
+            foreach (var invalid in invalidChars)
+            {
+                safe = safe.Replace(invalid, '-');
+            }
+            while (safe.Contains("--"))
+            {
+                safe = safe.Replace("--", "-");
+            }
+            safe = safe.Trim('-');
+            return string.IsNullOrWhiteSpace(safe) ? "generated-report" : safe;
+        }
+
+        private static IEnumerable<string> ResolveContentControlTitles(WordModel wordModel)
+        {
+            var controls = wordModel?.ContentControls ?? new List<WordContentControl>();
+            return controls
+                .Select(control => control?.Title?.Trim())
+                .Where(title => !string.IsNullOrWhiteSpace(title))
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private string BuildTemporaryTemplate(WordModel wordModel)
+        {
+            var fileNameBase = Path.GetFileNameWithoutExtension(wordModel?.UploadProperties?.FileName ?? "generated-report.docx");
+            var safeBaseName = NormalizeFileToken(fileNameBase);
+            var tempDirectoryPath = Path.Combine(Path.GetTempPath(), $"json-to-word-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDirectoryPath);
+            var tempTemplatePath = Path.Combine(tempDirectoryPath, $"{safeBaseName}.docx");
+            var contentControlTitles = ResolveContentControlTitles(wordModel).ToList();
+
+            using (var document = WordprocessingDocument.Create(tempTemplatePath, WordprocessingDocumentType.Document))
+            {
+                var mainPart = document.AddMainDocumentPart();
+                mainPart.Document = new Document(new Body());
+                var body = mainPart.Document.Body;
+
+                if (contentControlTitles.Count == 0)
+                {
+                    body.AppendChild(new Paragraph(new Run(new Text("Generated document"))));
+                }
+                else
+                {
+                    foreach (var title in contentControlTitles)
+                    {
+                        var sdtBlock = new SdtBlock(
+                            new SdtProperties(
+                                new SdtAlias { Val = title },
+                                new Tag { Val = title }
+                            ),
+                            new SdtContentBlock(
+                                new Paragraph(
+                                    new Run(
+                                        new Text("Click or tap here to enter text.")
+                                    )
+                                )
+                            )
+                        );
+                        body.AppendChild(sdtBlock);
+                        body.AppendChild(new Paragraph());
+                    }
+                }
+
+                mainPart.Document.Save();
+            }
+
+            return tempTemplatePath;
+        }
+
+        private static void AddCleanupPath(ISet<string> cleanupPaths, string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+            cleanupPaths.Add(path);
+        }
+
+        private static bool IsGeneratedTempDirectory(string directoryPath)
+        {
+            if (string.IsNullOrWhiteSpace(directoryPath))
+            {
+                return false;
+            }
+
+            var directoryName = Path.GetFileName(
+                directoryPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            );
+            return directoryName.StartsWith("json-to-word-", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void SafeCleanUp(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            try
+            {
+                _aWSS3Service.CleanUp(path);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed cleaning temporary file {Path}", path);
+            }
+
+            try
+            {
+                var parentDirectory = Path.GetDirectoryName(path);
+                if (!IsGeneratedTempDirectory(parentDirectory))
+                {
+                    return;
+                }
+
+                if (Directory.Exists(parentDirectory) && !Directory.EnumerateFileSystemEntries(parentDirectory).Any())
+                {
+                    Directory.Delete(parentDirectory, false);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed deleting temporary directory for {Path}", path);
             }
         }
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,3 +1,8 @@
 # json-to-word
 An engine to generate docx files from json objects-
 [![Gitter](https://badges.gitter.im/json-to-word/community.svg)](https://gitter.im/json-to-word/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
+## Notes
+
+- `POST /api/word/create` now supports template-less payloads.  
+  When `TemplatePath` is missing/non-absolute, the controller builds a temporary `.docx` with content controls from `ContentControls[*].Title` and then runs the normal `WordService` pipeline.


### PR DESCRIPTION
…mpare report generation in json-to-word pipeline

Enable json-to-word to process historical compare report requests.

- Update Word controller flow to support historical compare content-control payloads.
- Support template-less generation path required by time-machine compare reports.
- Keep existing generation paths intact while adding historical routing behavior.
- Update README and controller tests for new report contract.

Validation:
- Word controller tests expanded and passing for historical compare scenarios.