### PR TITLE
#281040 fix(word): clear legacy default content controls

### DIFF
--- a/JsonToWord.Tests/Services.Tests/ContentControlServiceTests.cs
+++ b/JsonToWord.Tests/Services.Tests/ContentControlServiceTests.cs
@@ -87,6 +87,29 @@ namespace JsonToWord.Services.Tests
         }
 
         [Fact]
+        public void ClearContentControl_RemovesLegacyDefaultContentBlock()
+        {
+            using var stream = new MemoryStream();
+            using var document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document, true);
+            var mainPart = document.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body());
+
+            var sdtBlock = new SdtBlock(
+                new SdtProperties(new SdtAlias { Val = "cc3-legacy" }),
+                new SdtContentBlock(new Paragraph(new Run(new Text("Click here to enter text."))))
+            );
+            mainPart.Document.Body.Append(sdtBlock);
+
+            var validator = new Mock<IDocumentValidatorService>();
+            var logger = new Mock<ILogger<ContentControlService>>();
+            var service = new ContentControlService(logger.Object, validator.Object);
+
+            service.ClearContentControl(document, "cc3-legacy", false);
+
+            Assert.False(sdtBlock.Elements<SdtContentBlock>().Any());
+        }
+
+        [Fact]
         public void ClearContentControl_AllowsRunLevelControlWithoutThrowing()
         {
             using var stream = new MemoryStream();

--- a/src/Services/ContentControlService.cs
+++ b/src/Services/ContentControlService.cs
@@ -64,7 +64,10 @@ namespace JsonToWord.Services
                 throw new Exception("Did not find a content control with the title " + contentControlTitle);
             }
 
-            if ((!string.IsNullOrEmpty(sdtBlock.InnerText) && sdtBlock.InnerText == "Click or tap here to enter text.") || force)
+            var trimmed = sdtBlock.InnerText?.Trim();
+            if (force ||
+                trimmed == "Click or tap here to enter text." ||
+                trimmed == "Click here to enter text.")
                 RemoveAllStdContentBlock(sdtBlock);
         }
 


### PR DESCRIPTION
Handle both modern and legacy Word placeholder text when clearing block content controls.

Some SysRS templates contain the older placeholder text "Click here to enter text." instead of the newer
"Click or tap here to enter text.". The content-control clearing logic now trims the inner text and removes either placeholder form before rendering new content.

Changes:
- trim content-control inner text before placeholder comparison
- clear controls containing the legacy default placeholder
- keep force-clear behavior unchanged
- add a regression test for legacy placeholder content blocks