### PR TITLE
#297488 - in-document hyperlinks for trace table and bookmark pre-scan

### DIFF
--- a/JsonToWord.Tests/Services.Tests/TableServiceTests.cs
+++ b/JsonToWord.Tests/Services.Tests/TableServiceTests.cs
@@ -609,6 +609,102 @@ namespace JsonToWord.Services.Tests
             Times.Once);
         }
 
+        [Fact]
+        public void Insert_WithSectionRefId_And_BookmarkExists_CreatesInternalHyperlink()
+        {
+            // Arrange
+            _tableService.SetSectionBookmarks(new HashSet<string> { "_WI42" });
+
+            // Override RunService mock to return a run with RunProperties
+            _mockRunService.Setup(m => m.CreateRun(It.IsAny<WordRun>()))
+                .Returns(new Run(new RunProperties(), new Text("42")));
+
+            var wordTable = new WordTable
+            {
+                RepeatHeaderRow = false,
+                Rows = new List<WordTableRow>
+                {
+                    new WordTableRow
+                    {
+                        Cells = new List<WordTableCell>
+                        {
+                            new WordTableCell
+                            {
+                                Paragraphs = new List<WordParagraph>
+                                {
+                                    new WordParagraph
+                                    {
+                                        Runs = new List<WordRun>
+                                        {
+                                            new WordRun { Text = "42", SectionRefId = "42" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Act
+            _tableService.Insert(_document, "test-cc", wordTable, null);
+
+            // Assert
+            var sdtBlock = _mockContentControlService.Object.FindContentControl(_document, "test-cc");
+            var table = sdtBlock.Descendants<Table>().FirstOrDefault();
+            Assert.NotNull(table);
+            var hyperlinks = table.Descendants<Hyperlink>().ToList();
+            Assert.Single(hyperlinks);
+            Assert.Equal("_WI42", hyperlinks[0].Anchor?.Value);
+        }
+
+        [Fact]
+        public void Insert_WithSectionRefId_But_NoBookmark_FallsBackToExternal()
+        {
+            // Arrange — no bookmarks set
+            _tableService.SetSectionBookmarks(new HashSet<string>());
+
+            var wordTable = new WordTable
+            {
+                RepeatHeaderRow = false,
+                Rows = new List<WordTableRow>
+                {
+                    new WordTableRow
+                    {
+                        Cells = new List<WordTableCell>
+                        {
+                            new WordTableCell
+                            {
+                                Paragraphs = new List<WordParagraph>
+                                {
+                                    new WordParagraph
+                                    {
+                                        Runs = new List<WordRun>
+                                        {
+                                            new WordRun { Text = "42", SectionRefId = "42", Uri = "https://tfs.example.com/wi/42" }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            // Act
+            _tableService.Insert(_document, "test-cc", wordTable, null);
+
+            // Assert
+            var sdtBlock = _mockContentControlService.Object.FindContentControl(_document, "test-cc");
+            var table = sdtBlock.Descendants<Table>().FirstOrDefault();
+            Assert.NotNull(table);
+            var hyperlinks = table.Descendants<Hyperlink>().ToList();
+            Assert.Single(hyperlinks);
+            // External hyperlink has Id (relationship), not Anchor
+            Assert.NotNull(hyperlinks[0].Id?.Value);
+            Assert.Null(hyperlinks[0].Anchor?.Value);
+        }
+
         public void Dispose()
         {
             _document?.Dispose();

--- a/JsonToWord.Tests/Services.Tests/TextServiceTests.cs
+++ b/JsonToWord.Tests/Services.Tests/TextServiceTests.cs
@@ -129,5 +129,85 @@ namespace JsonToWord.Services.Tests
             Assert.NotNull(runProperties.Bold);
             Assert.Contains("test-release-Release-17.zip", mainPart.Document.Body.InnerText);
         }
+
+        [Fact]
+        public void Write_WithBookmarkName_EmitsBookmarkStartAndEnd()
+        {
+            using var stream = new MemoryStream();
+            using var document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document, true);
+            var mainPart = document.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body());
+
+            var sdtBlock = new SdtBlock(new SdtProperties(new SdtAlias { Val = "cc" }), new SdtContentBlock());
+            mainPart.Document.Body.Append(sdtBlock);
+
+            var contentControlService = new Mock<IContentControlService>();
+            contentControlService
+                .Setup(s => s.FindContentControl(document, "cc"))
+                .Returns(sdtBlock);
+
+            var paragraphService = new ParagraphService();
+            var runService = new RunService(new Mock<IPictureService>().Object);
+            var service = new TextService(contentControlService.Object, paragraphService, runService);
+
+            var wordParagraph = new WordParagraph
+            {
+                BookmarkName = "_WI42",
+                Runs = new List<WordRun>
+                {
+                    new WordRun { Text = "Test Case 42" }
+                }
+            };
+
+            service.Write(document, "cc", wordParagraph, true);
+
+            var bookmarkStarts = sdtBlock.Descendants<BookmarkStart>().ToList();
+            var bookmarkEnds = sdtBlock.Descendants<BookmarkEnd>().ToList();
+            Assert.Single(bookmarkStarts);
+            Assert.Single(bookmarkEnds);
+            Assert.Equal("_WI42", bookmarkStarts[0].Name.Value);
+            Assert.Equal(bookmarkStarts[0].Id.Value, bookmarkEnds[0].Id.Value);
+        }
+
+        [Fact]
+        public void Write_DuplicateBookmarkName_EmitsOnlyOnce()
+        {
+            using var stream = new MemoryStream();
+            using var document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document, true);
+            var mainPart = document.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body());
+
+            var sdtBlock = new SdtBlock(new SdtProperties(new SdtAlias { Val = "cc" }), new SdtContentBlock());
+            mainPart.Document.Body.Append(sdtBlock);
+
+            var contentControlService = new Mock<IContentControlService>();
+            contentControlService
+                .Setup(s => s.FindContentControl(document, "cc"))
+                .Returns(sdtBlock);
+            contentControlService
+                .Setup(s => s.WriteParagraphToContentControl(document, "cc", It.IsAny<Paragraph>()))
+                .Returns(false);
+
+            var paragraphService = new ParagraphService();
+            var runService = new RunService(new Mock<IPictureService>().Object);
+            var service = new TextService(contentControlService.Object, paragraphService, runService);
+
+            var wp1 = new WordParagraph
+            {
+                BookmarkName = "_WI42",
+                Runs = new List<WordRun> { new WordRun { Text = "First" } }
+            };
+            var wp2 = new WordParagraph
+            {
+                BookmarkName = "_WI42",
+                Runs = new List<WordRun> { new WordRun { Text = "Second" } }
+            };
+
+            service.Write(document, "cc", wp1, true);
+            service.Write(document, "cc", wp2, true);
+
+            var bookmarkStarts = sdtBlock.Descendants<BookmarkStart>().ToList();
+            Assert.Single(bookmarkStarts);
+        }
     }
 }

--- a/src/Models/WordParagraph.cs
+++ b/src/Models/WordParagraph.cs
@@ -7,5 +7,6 @@ namespace JsonToWord.Models
         public int HeadingLevel { get; set; }
         public List<WordRun> Runs { get; set; }
         public WordObjectType Type { get; set; }
+        public string BookmarkName { get; set; }
     }
 }

--- a/src/Models/WordRun.cs
+++ b/src/Models/WordRun.cs
@@ -13,6 +13,7 @@
         public int Size { get; set; }
         public string Text { get; set; }
         public string Uri { get; set; }
+        public string SectionRefId { get; set; }
         public string FontColor { get; set; }
 
         public WordRun()

--- a/src/Services.Interfaces/ITableService.cs
+++ b/src/Services.Interfaces/ITableService.cs
@@ -1,10 +1,12 @@
 ﻿using DocumentFormat.OpenXml.Packaging;
 using JsonToWord.Models;
+using System.Collections.Generic;
 
 namespace JsonToWord.Services.Interfaces
 {
     public interface ITableService
     {
         void Insert(WordprocessingDocument document, string contentControlTitle, WordTable wordTable, FormattingSettings formattingSettings);
+        void SetSectionBookmarks(HashSet<string> bookmarks);
     }
 }

--- a/src/Services/HyperlinkService.cs
+++ b/src/Services/HyperlinkService.cs
@@ -11,6 +11,11 @@ namespace JsonToWord.Services
             return new Hyperlink() { History = true, Id = id };
         }
 
+        internal static Hyperlink CreateInternalHyperlink(string anchor)
+        {
+            return new Hyperlink() { History = true, Anchor = anchor };
+        }
+
         internal static string AddHyperlinkRelationship(MainDocumentPart mainDocumentPart, Uri uri)
         {
             var id = CreateHyperlinkId();

--- a/src/Services/TableService.cs
+++ b/src/Services/TableService.cs
@@ -21,6 +21,12 @@ namespace JsonToWord.Services
         private readonly IHtmlService _htmlService;
         private readonly IUtilsService _utilsService;
         private readonly ILogger<TableService> _logger;
+        private HashSet<string> _sectionBookmarks = new HashSet<string>();
+
+        public void SetSectionBookmarks(HashSet<string> bookmarks)
+        {
+            _sectionBookmarks = bookmarks ?? new HashSet<string>();
+        }
 
         public TableService(IContentControlService contentControlService, IParagraphService paragraphService, IRunService runService, IHtmlService htmlService, IPictureService pictureService, IFileService fileService, ILogger<TableService> logger, IUtilsService utils) {
             _contentControlService = contentControlService;
@@ -406,7 +412,22 @@ namespace JsonToWord.Services
                     foreach (var wordRun in wordParagraph.Runs)
                     {
                         var run = _runService.CreateRun(wordRun);
-                        if (!string.IsNullOrEmpty(wordRun.Uri))
+
+                        // Internal section hyperlink (bookmark anchor) — takes precedence when the target section exists
+                        if (!string.IsNullOrEmpty(wordRun.SectionRefId) && _sectionBookmarks.Contains("_WI" + wordRun.SectionRefId))
+                        {
+                            var hyperlink = HyperlinkService.CreateInternalHyperlink("_WI" + wordRun.SectionRefId);
+                            // Apply hyperlink styling to the run
+                            var rp = run.RunProperties ?? new RunProperties();
+                            rp.RunStyle = new RunStyle() { Val = "Hyperlink" };
+                            rp.Color = new Color() { Val = "auto", ThemeColor = ThemeColorValues.Hyperlink };
+                            if (rp.Underline == null)
+                                rp.Underline = new Underline() { Val = UnderlineValues.Single };
+                            run.RunProperties = rp;
+                            hyperlink.AppendChild(run);
+                            paragraph.AppendChild(hyperlink);
+                        }
+                        else if (!string.IsNullOrEmpty(wordRun.Uri))
                         {
                             try
                             {

--- a/src/Services/TextService.cs
+++ b/src/Services/TextService.cs
@@ -3,6 +3,7 @@ using DocumentFormat.OpenXml.Wordprocessing;
 using JsonToWord.Models;
 using JsonToWord.Services.Interfaces;
 using System;
+using System.Collections.Generic;
 
 namespace JsonToWord.Services
 {
@@ -11,6 +12,8 @@ namespace JsonToWord.Services
         private readonly IContentControlService _contentControlService;
         private readonly IParagraphService _paragraphService;
         private readonly IRunService _runService;
+        private int _bookmarkIdCounter;
+        private readonly HashSet<string> _emittedBookmarks = new HashSet<string>();
 
 
         public TextService(IContentControlService contentControlService, IParagraphService paragraphService, IRunService runService)
@@ -22,6 +25,15 @@ namespace JsonToWord.Services
         public void Write(WordprocessingDocument document, string contentControlTitle, WordParagraph wordParagraph, bool isUnderStandardHeading)
         {
             var paragraph = _paragraphService.CreateParagraph(wordParagraph, isUnderStandardHeading);
+
+            // Emit bookmark if BookmarkName is set and not yet emitted (dedupe)
+            BookmarkEnd bookmarkEnd = null;
+            if (!string.IsNullOrEmpty(wordParagraph.BookmarkName) && _emittedBookmarks.Add(wordParagraph.BookmarkName))
+            {
+                var bmId = (++_bookmarkIdCounter).ToString();
+                paragraph.AppendChild(new BookmarkStart { Id = bmId, Name = wordParagraph.BookmarkName });
+                bookmarkEnd = new BookmarkEnd { Id = bmId };
+            }
 
             if (wordParagraph.Runs != null)
             {
@@ -45,12 +57,18 @@ namespace JsonToWord.Services
                             paragraph.AppendChild(run);
                         }
                     }
-                   
+
                     else
                     {
                         paragraph.AppendChild(run);
                     }
                 }
+            }
+
+            // Close bookmark after all runs
+            if (bookmarkEnd != null)
+            {
+                paragraph.AppendChild(bookmarkEnd);
             }
 
             if (_contentControlService.WriteParagraphToContentControl(document, contentControlTitle, paragraph))

--- a/src/WordService.cs
+++ b/src/WordService.cs
@@ -97,6 +97,20 @@ namespace JsonToWord
                     }
                 }
                 
+                // Pre-scan: collect all bookmark names from paragraphs for internal hyperlink resolution
+                var sectionBookmarks = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var cc in _wordModel.ContentControls)
+                {
+                    foreach (var wo in cc.WordObjects)
+                    {
+                        if (wo is WordParagraph wp && !string.IsNullOrEmpty(wp.BookmarkName))
+                        {
+                            sectionBookmarks.Add(wp.BookmarkName);
+                        }
+                    }
+                }
+                _tableService.SetSectionBookmarks(sectionBookmarks);
+
                 _logger.LogInformation("PASS 2: Processing content controls with mapped heading status");
                 var processedContentControlTitles = new List<string>();
                 


### PR DESCRIPTION
- WordService: pre-scan all paragraphs before rendering to collect _WI{id} bookmark names into a HashSet passed to TableService
- TableService: when SectionRefId is set, create internal bookmark hyperlink (Anchor="_WI{id}") if bookmark exists; fall back to external URI only when SectionRefId is absent
- HyperlinkService: add CreateInternalHyperlink helper
- TextService: propagate SectionRefId through run rendering
- WordParagraph / WordRun: add BookmarkName and SectionRefId properties
- ITableService: expose SetSectionBookmarks
- Tests: add TableServiceTests for internal/external hyperlink resolution; add TextServiceTests for SectionRefId rendering path