### PR TITLE
#286919 - Auto-fill current month/year content control

### DIFF
--- a/JsonToWord.Tests/Services.Tests/ContentControlServiceTests.cs
+++ b/JsonToWord.Tests/Services.Tests/ContentControlServiceTests.cs
@@ -165,6 +165,39 @@ namespace JsonToWord.Services.Tests
         }
 
         [Fact]
+        public void WritePlainTextToContentControl_WritesIntoSdtRun()
+        {
+            using var stream = new MemoryStream();
+            using var document = WordprocessingDocument.Create(stream, WordprocessingDocumentType.Document, true);
+            var mainPart = document.AddMainDocumentPart();
+            mainPart.Document = new Document(new Body());
+
+            var sdtRun = new SdtRun(
+                new SdtProperties(
+                    new SdtAlias { Val = "current-month-year-content-control" },
+                    new Tag { Val = "current-month-year-content-control" }),
+                new SdtContentRun(
+                    new Run(
+                        new RunProperties(new Bold()),
+                        new Text("February 2020")))
+            );
+            mainPart.Document.Body.Append(new Paragraph(sdtRun));
+
+            var validator = new Mock<IDocumentValidatorService>();
+            var logger = new Mock<ILogger<ContentControlService>>();
+            var service = new ContentControlService(logger.Object, validator.Object);
+
+            var result = service.WritePlainTextToContentControl(
+                document,
+                "current-month-year-content-control",
+                "July 2026");
+
+            Assert.True(result);
+            Assert.Equal("July 2026", sdtRun.InnerText);
+            Assert.NotNull(sdtRun.Descendants<Bold>().FirstOrDefault());
+        }
+
+        [Fact]
         public void ClearContentControl_DoesNotRemove_WhenNotForced()
         {
             using var stream = new MemoryStream();

--- a/JsonToWord.Tests/Services.Tests/WordServiceTests.cs
+++ b/JsonToWord.Tests/Services.Tests/WordServiceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using DocumentFormat.OpenXml;
@@ -142,6 +143,106 @@ namespace JsonToWord.Services.Tests
 
                 Assert.Equal(templatePath, resultPath);
                 mocks.VoidListService.Verify(v => v.CreateVoidList(It.IsAny<string>()), Times.Never);
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Fact]
+        public void Create_WhenCurrentMonthYearControlExists_FillsAndRemovesControl()
+        {
+            var mocks = CreateServiceWithMocks();
+            var service = mocks.Service;
+
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            var templatePath = Path.Combine(tempDir, "template.docx");
+
+            try
+            {
+                using (var doc = WordprocessingDocument.Create(templatePath, WordprocessingDocumentType.Document))
+                {
+                    var mainPart = doc.AddMainDocumentPart();
+                    mainPart.Document = new Document(new Body(new Paragraph(new Run(new Text("content")))));
+                }
+
+                mocks.DocumentService
+                    .Setup(d => d.CreateDocument(templatePath))
+                    .Returns(templatePath);
+
+                var expectedDate = DateTime.Now.ToString("MMMM yyyy", CultureInfo.InvariantCulture);
+                mocks.ContentControlService
+                    .Setup(c => c.WritePlainTextToContentControl(
+                        It.IsAny<WordprocessingDocument>(),
+                        "current-month-year-content-control",
+                        expectedDate))
+                    .Returns(true);
+
+                var model = new WordModel
+                {
+                    LocalPath = templatePath,
+                    ContentControls = new List<WordContentControl>(),
+                    FormattingSettings = new FormattingSettings { ProcessVoidList = false }
+                };
+
+                service.Create(model);
+
+                mocks.ContentControlService.Verify(c => c.WritePlainTextToContentControl(
+                    It.IsAny<WordprocessingDocument>(),
+                    "current-month-year-content-control",
+                    expectedDate), Times.Once);
+                mocks.ContentControlService.Verify(c => c.RemoveContentControl(
+                    It.IsAny<WordprocessingDocument>(),
+                    "current-month-year-content-control"), Times.Once);
+            }
+            finally
+            {
+                Directory.Delete(tempDir, true);
+            }
+        }
+
+        [Fact]
+        public void Create_WhenCurrentMonthYearControlIsMissing_DoesNotRemoveControl()
+        {
+            var mocks = CreateServiceWithMocks();
+            var service = mocks.Service;
+
+            var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            var templatePath = Path.Combine(tempDir, "template.docx");
+
+            try
+            {
+                using (var doc = WordprocessingDocument.Create(templatePath, WordprocessingDocumentType.Document))
+                {
+                    var mainPart = doc.AddMainDocumentPart();
+                    mainPart.Document = new Document(new Body(new Paragraph(new Run(new Text("content")))));
+                }
+
+                mocks.DocumentService
+                    .Setup(d => d.CreateDocument(templatePath))
+                    .Returns(templatePath);
+                mocks.ContentControlService
+                    .Setup(c => c.WritePlainTextToContentControl(
+                        It.IsAny<WordprocessingDocument>(),
+                        "current-month-year-content-control",
+                        It.IsAny<string>()))
+                    .Returns(false);
+
+                var model = new WordModel
+                {
+                    LocalPath = templatePath,
+                    ContentControls = new List<WordContentControl>(),
+                    FormattingSettings = new FormattingSettings { ProcessVoidList = false }
+                };
+
+                service.Create(model);
+
+                mocks.ContentControlService.Verify(c => c.RemoveContentControl(
+                    It.IsAny<WordprocessingDocument>(),
+                    "current-month-year-content-control"), Times.Never);
             }
             finally
             {

--- a/src/Services/ContentControlService.cs
+++ b/src/Services/ContentControlService.cs
@@ -122,6 +122,32 @@ namespace JsonToWord.Services
                 return true;
             }
 
+            var sdtRun = body.Descendants<SdtRun>()
+                .FirstOrDefault(e =>
+                {
+                    var alias = e.SdtProperties?.GetFirstChild<SdtAlias>()?.Val?.Value;
+                    var tag = e.SdtProperties?.GetFirstChild<Tag>()?.Val?.Value;
+                    return ContentControlMatches(alias, tag, contentControlTitle);
+                });
+            if (sdtRun != null)
+            {
+                var contentRun = sdtRun.GetFirstChild<SdtContentRun>();
+                if (contentRun == null)
+                {
+                    contentRun = new SdtContentRun();
+                    sdtRun.AppendChild(contentRun);
+                }
+
+                var runProperties = contentRun.Descendants<RunProperties>().FirstOrDefault()?.CloneNode(true);
+                contentRun.RemoveAllChildren();
+                var run = new Run();
+                if (runProperties != null)
+                    run.Append(runProperties);
+                run.Append(new Text(safeText));
+                contentRun.Append(run);
+                return true;
+            }
+
             return false;
         }
 

--- a/src/WordService.cs
+++ b/src/WordService.cs
@@ -7,6 +7,7 @@ using JsonToWord.Services.Interfaces;
 using ICSharpCode.SharpZipLib.Zip;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace JsonToWord
@@ -25,6 +26,7 @@ namespace JsonToWord
         private readonly IDocumentService _documentService;
         private readonly ISectionPlaceholderService _sectionPlaceholderService;
         private bool _isZipNeeded = false;
+        private const string CurrentMonthYearContentControlTitle = "current-month-year-content-control";
         #endregion
         
         #region Constructor
@@ -60,6 +62,7 @@ namespace JsonToWord
             using (var document = WordprocessingDocument.Open(documentPath, true))
             {
                 _logger.LogInformation("Starting on doc path: " + documentPath);
+                FillCurrentMonthYearContentControl(document);
                 
                 // PASS 1: Build the content control heading status map
                 _logger.LogInformation("PASS 1: Analyzing all content controls to determine heading status");
@@ -201,6 +204,27 @@ namespace JsonToWord
             return generatedDocPath;
             //documentService.RunMacro(documentPath, "updateTableOfContent",sw);
             //log.Info("Ran Macro");
+        }
+
+        private void FillCurrentMonthYearContentControl(WordprocessingDocument document)
+        {
+            var currentMonthYear = DateTime.Now.ToString("MMMM yyyy", CultureInfo.InvariantCulture);
+            var wroteDate = _contentControlService.WritePlainTextToContentControl(
+                document,
+                CurrentMonthYearContentControlTitle,
+                currentMonthYear);
+
+            if (!wroteDate)
+                return;
+
+            try
+            {
+                _contentControlService.RemoveContentControl(document, CurrentMonthYearContentControlTitle);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error removing content control: " + CurrentMonthYearContentControlTitle);
+            }
         }
 
         public DownloadableObjectModel CreateDownloadableFile(string docPath)


### PR DESCRIPTION
- Add automatic population for current month/year template content control
- Support writing plain text into run-level Word content controls
- Add regression tests for optional date control behavior and run-level content control writing